### PR TITLE
[fix] Fixed QMap iterator doesn't have first but key() instead

### DIFF
--- a/xwriter.h
+++ b/xwriter.h
@@ -66,7 +66,7 @@ public:
     doc_type& convert(const char*key, const QMap<QString, T>&data) {
         std::map<std::string, T> sm;
         for (typename QMap<QString, T>::const_iterator iter=data.begin(); iter!=data.end(); iter++) {
-            sm[iter->first.toStdString()] = iter->second;
+            sm[iter.key().toStdString()] = iter.value();
         }
         doc_type *dt = (doc_type*)this;
         dt->convert(key, sm);


### PR DESCRIPTION
QMap iterator does not have first/second field, but use key() and value() function to obtain such items instead.