### PR TITLE
[fix] Prevent using deprecated QList API

### DIFF
--- a/xreader.h
+++ b/xreader.h
@@ -375,7 +375,7 @@ public:
         std::list<T> sl;
         bool ret = ((doc_type*)this)->convert(key, sl);
         if (ret) {
-            val = QList<T>::fromStdList(sl);
+            val = QList<T>(sl.begin(), sl.end());
         }
         return ret;
     }

--- a/xwriter.h
+++ b/xwriter.h
@@ -48,7 +48,7 @@ public:
 
     template<typename T>
     doc_type& convert(const char*key, const QList<T>&data) {
-        std::list<T> sl = data.toStdList();
+        std::list<T> sl = std::list<T>(data.begin(), data.end());
         doc_type *dt = (doc_type*)this;
         dt->convert(key, sl);
         return *dt;


### PR DESCRIPTION
Since Qt 5.14 is released recently, `toStdList` and `fromStdList` in QList class have been marked as deprecated.
It's a wise choice to prevent using them.